### PR TITLE
fix bug: race in h264bsd_worker.js

### DIFF
--- a/js/h264bsd_worker.js
+++ b/js/h264bsd_worker.js
@@ -64,7 +64,7 @@ function onHeadersReady() {
     });
 }
 
-function decodeLoop() {
+function decodeOnce() {
     var result = decoder.decode();
 
     switch(result) {
@@ -82,8 +82,17 @@ function decodeLoop() {
         postMessage({'type': 'noInput'});
         break;
     default:
-        setTimeout(decodeLoop, 0);
+        return true
     }
+    return false
+}
+
+function decodeLoop() {
+  while (true) {
+    if(!decodeOnce()) {
+        return
+    }
+  }
 }
 
 addEventListener('message', onMessage);

--- a/wasm/h264bsd_worker.js
+++ b/wasm/h264bsd_worker.js
@@ -64,7 +64,7 @@ function onHeadersReady() {
     });
 }
 
-function decodeLoop() {
+function decodeOnce() {
     var result = decoder.decode();
 
     switch(result) {
@@ -82,8 +82,17 @@ function decodeLoop() {
         postMessage({'type': 'noInput'});
         break;
     default:
-        setTimeout(decodeLoop, 0);
+        return true
     }
+    return false
+}
+
+function decodeLoop() {
+  while (true) {
+    if(!decodeOnce()) {
+        return
+    }
+  }
 }
 
 addEventListener('message', onMessage);


### PR DESCRIPTION
In my case, web client  connect to server by websocket to receive a H264 Annex B stream.

Sometime, it raced in decoder.queueInput() and decodeLoop() .